### PR TITLE
Replaced dpkg with APT

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Install package
       run: |
           sudo dpkg -i ./build/wireguird_amd64.deb
+          sudo apt-get -f install
 
 
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -34,8 +34,8 @@ jobs:
     
     - name: Install package
       run: |
-          sudo dpkg -i ./build/wireguird_amd64.deb
-          sudo apt-get -f install
+          sudo apt install ./build/wireguird_amd64.deb
+
 
 
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -34,7 +34,7 @@ jobs:
     
     - name: Install package
       run: |
-          dpkg -i ./build/wireguird_amd64.deb
+          sudo dpkg -i ./build/wireguird_amd64.deb
 
 
 


### PR DESCRIPTION
Replaced dpkg for APT on the package installation test. This will now install all necessary dependencies automatically.